### PR TITLE
feat: convert OutlookEvent struct to GoogleEvent struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "colored"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +802,7 @@ version = "0.1.0"
 dependencies = [
  "blocking",
  "chrono",
+ "chrono-tz",
  "ical",
  "mockito",
  "oauth2",
@@ -981,10 +1004,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -1459,6 +1529,12 @@ name = "similar"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,7 @@ name = "lookout_g"
 version = "0.1.0"
 dependencies = [
  "blocking",
+ "chrono",
  "ical",
  "mockito",
  "oauth2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 blocking = "1.6.1"
+chrono = "0.4.38"
 ical = "0.11.0"
 oauth2 = { version = "4.4.2", features = ["reqwest"] }
 reqwest = { version = "0.12.5", features = ["json", "blocking"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 blocking = "1.6.1"
 chrono = "0.4.38"
+chrono-tz = "0.9.0"
 ical = "0.11.0"
 oauth2 = { version = "4.4.2", features = ["reqwest"] }
 reqwest = { version = "0.12.5", features = ["json", "blocking"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,17 @@ pub fn outlook_to_google(outlook_event: OutlookEvent) -> GoogleEvent {
 }
 
 pub fn convert_event_datetime(event_datetime: OutlookEventDateTime) -> GoogleEventDateTime {
+    fn date_time_to_google_date(date_str: &str) -> Option<String> {
+        if date_str.len() >= 8 {
+            let year = &date_str[0..4];
+            let month = &date_str[4..6];
+            let day = &date_str[6..8];
+            Some(format!("{}-{}-{}", year, month, day))
+        } else {
+            None
+        }
+    }
+
     // Extract timeZone from params if available
     let time_zone = event_datetime.params.and_then(|params| {
         params.iter().find_map(|(key, values)| {
@@ -77,7 +88,7 @@ pub fn convert_event_datetime(event_datetime: OutlookEventDateTime) -> GoogleEve
     });
 
     GoogleEventDateTime {
-        date: None, // Not applicable in this conversion, leaving it as None
+        date: date_time_to_google_date(&event_datetime.date_time),
         date_time: Some(event_datetime.date_time),
         time_zone,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ impl Config {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Event {
+pub struct OutlookEvent {
     pub id: Option<String>,
     pub summary: String,
     pub location: Option<String>,
@@ -36,7 +36,7 @@ pub struct EventDateTime {
     pub params: Option<Vec<(String, Vec<String>)>>,
 }
 
-pub fn fetch_and_parse_ics(ics_url: &str) -> Result<Vec<Event>, Box<dyn Error>> {
+pub fn fetch_and_parse_ics(ics_url: &str) -> Result<Vec<OutlookEvent>, Box<dyn Error>> {
     let response = get(ics_url)?;
     let ics_data = response.bytes()?;
 
@@ -50,7 +50,7 @@ pub fn fetch_and_parse_ics(ics_url: &str) -> Result<Vec<Event>, Box<dyn Error>> 
                 for ical_event in calendar.events {
                     let init_params: Option<Vec<(String, Vec<String>)>> = Some(Vec::new());
 
-                    let mut event = Event {
+                    let mut event = OutlookEvent {
                         id: None,
                         summary: String::new(),
                         location: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
 use ical::IcalParser;
 use reqwest::blocking::get;
 use serde::{Deserialize, Serialize};
@@ -76,6 +77,17 @@ pub fn convert_event_datetime(event_datetime: OutlookEventDateTime) -> GoogleEve
         }
     }
 
+    fn date_time_to_rfc3339(date_str: &str) -> Option<String> {
+        if date_str.len() >= 15 {
+            let naive_date_time = NaiveDateTime::parse_from_str(date_str, "%Y%m%dT%H%M%S").ok()?;
+            let date_time: DateTime<Utc> =
+                DateTime::from_naive_utc_and_offset(naive_date_time, Utc);
+            Some(date_time.to_rfc3339())
+        } else {
+            None
+        }
+    }
+
     // Extract timeZone from params if available
     let time_zone = event_datetime.params.and_then(|params| {
         params.iter().find_map(|(key, values)| {
@@ -89,7 +101,7 @@ pub fn convert_event_datetime(event_datetime: OutlookEventDateTime) -> GoogleEve
 
     GoogleEventDateTime {
         date: date_time_to_google_date(&event_datetime.date_time),
-        date_time: Some(event_datetime.date_time),
+        date_time: date_time_to_rfc3339(&event_datetime.date_time),
         time_zone,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ impl Config {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Event {
+    pub id: Option<String>,
     pub summary: String,
     pub location: Option<String>,
     pub description: Option<String>,
@@ -48,6 +49,7 @@ pub fn fetch_and_parse_ics(ics_url: &str) -> Result<Vec<Event>, Box<dyn Error>> 
             Ok(calendar) => {
                 for ical_event in calendar.events {
                     let mut event = Event {
+                        id: None,
                         summary: String::new(),
                         location: None,
                         description: None,
@@ -62,6 +64,7 @@ pub fn fetch_and_parse_ics(ics_url: &str) -> Result<Vec<Event>, Box<dyn Error>> 
                     };
                     for property in ical_event.properties {
                         match property.name.as_str() {
+                            "UID" => event.id = property.value,
                             "SUMMARY" => event.summary = property.value.unwrap_or_default(),
                             "LOCATION" => event.location = property.value,
                             "DESCRIPTION" => event.description = property.value,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,8 +205,8 @@ BEGIN:VEVENT
 SUMMARY:Test Event
 LOCATION:Test Location
 DESCRIPTION:Test Description
-DTSTART:20230801T090000Z
-DTEND:20230801T100000Z
+DTSTART;TZID=Romance Standard Time:20230801T090000
+DTEND;TZID=Romance Standard Time:20230801T100000
 END:VEVENT
 END:VCALENDAR";
 
@@ -231,11 +231,19 @@ END:VCALENDAR";
         assert_eq!(events.len(), 1);
 
         let event = &events[0];
-        assert_eq!(event.summary, "Test Event");
+        assert_eq!(event.summary, Some(String::from("Test Event")));
         assert_eq!(event.location.as_deref(), Some("Test Location"));
         assert_eq!(event.description.as_deref(), Some("Test Description"));
-        assert_eq!(event.start.date_time, "20230801T090000Z");
-        assert_eq!(event.end.date_time, "20230801T100000Z");
+        assert_eq!(
+            event.start.date_time,
+            Some(String::from("2023-08-01T09:00:00+00:00"))
+        );
+        assert_eq!(
+            event.end.date_time,
+            Some(String::from("2023-08-01T10:00:00+00:00"))
+        );
+        assert_eq!(event.start.time_zone, Some(String::from("Europe/Paris")));
+        assert_eq!(event.end.time_zone, Some(String::from("Europe/Paris")));
 
         Ok(())
     }


### PR DESCRIPTION
In this PR, I add functionality to reformat the data structs pulled from the OutLook ICS file, and format as per the [Google Calendar API specs](https://developers.google.com/calendar/api/v3/reference/events) 

- **Event struct gains UID**
- **EventDateTime gains `params` field**
- **rename `Event` struct to more precise `OutlookEvent`**
- **implement Event struct cross-conversion**

Closes #3
